### PR TITLE
Patch scale_to_zero still being enabled despite None

### DIFF
--- a/trending_deploy/deploy.py
+++ b/trending_deploy/deploy.py
@@ -104,6 +104,7 @@ def deploy_model(model: Model) -> bool:
             "type": TYPE,
             "instance_size": instance_size, # Use the potentially upgraded size
             "instance_type": "intel-spr",
+            "min_replica": 1,
             "scale_to_zero_timeout": None,
             "domain": "api-inference.endpoints.huggingface.tech",
             "path": f"/models/{model_name}",


### PR DESCRIPTION
Hello!

## Pull Request overview
* [Patch scale_to_zero still being enabled despite None](https://github.com/huggingface/trending-deploy/commit/788c3b32b653a9ac23a6df37f81cd1c9826bb3cb)
* [Move instance size increases to separate function](https://github.com/huggingface/trending-deploy/commit/5b15dd4ccafe20a950335b4cd17bf371846cfff9)
* [Only set the image arguments when necessary, allow non-embedding/toke…](https://github.com/huggingface/trending-deploy/commit/5cbbee5050b2014221d7e32111e3aee9e4271340)

## Details
In short, `scale_to_zero_timeout=None` and `min_replica=1` does work to get no scale-to-zero. Both parameters are required, if you only use `min_replica=1`, then it'll complain that it's incompatible with a `scale_to_zero_timeout` value.

This also fixes [this issue](https://github.com/huggingface/trending-deploy/commit/eeaa05c9beb5e7df6f3f308acf4b0fd7d3308e4a#r156591287) where a poorly placed `return` prevents deployment of any model that doesn't fit with any of the custom images.

@Vaibhavs10 should we still increase the instance size for "TEI" models? I think that doesn't really make sense anymore

cc @Wauplin @hanouticelina ideally we should document this on the `huggingface_hub` side.

- Tom Aarsen