### PR TITLE
Add setup.py & simple script to deploy Scheduled Job on HF

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,6 @@
 # /// script
 # dependencies = [
-#     "trending_deploy @ git+https://github.com/tomaarsen/trending-deploy.git@scheduled_hf_jobs",
+#     "trending_deploy @ git+https://github.com/huggingface/trending-deploy.git",
 # ]
 # ///
 

--- a/cli.py
+++ b/cli.py
@@ -1,3 +1,9 @@
+# /// script
+# dependencies = [
+#     "trending_deploy @ git+https://github.com/tomaarsen/trending-deploy.git@scheduled_hf_jobs",
+# ]
+# ///
+
 import argparse
 import logging
 

--- a/scripts/schedule_hf_job.py
+++ b/scripts/schedule_hf_job.py
@@ -1,14 +1,14 @@
-from huggingface_hub import create_scheduled_uv_job
+from huggingface_hub import create_scheduled_uv_job, run_uv_job
 import os
 
 BUDGET = 500
 MAX_MODELS_PER_TASK = 30
 HF_TOKEN = os.environ["HF_TOKEN"]
+SCHEDULE = "@weekly"  # or "@daily", "@monthly", or None for one-time job
 
 def main():
-    create_scheduled_uv_job(
-        "https://raw.githubusercontent.com/tomaarsen/trending-deploy/refs/heads/scheduled_hf_jobs/cli.py",
-        script_args=[
+    kwargs = {
+        "script_args": [
             "--budget",
             str(BUDGET),
             "--max-models-per-task",
@@ -16,12 +16,23 @@ def main():
             "--verbose",
             "--dry",
         ],
-        schedule="@weekly",
-        secrets={"HF_TOKEN": HF_TOKEN},
-        flavor="cpu-basic",
-        timeout="8h",
-        namespace="hf-inference",
-    )
+        "secrets": {"HF_TOKEN": HF_TOKEN},
+        "flavor": "cpu-basic",
+        "timeout": "24h",
+        "namespace": "hf-inference",
+    }
+
+    if SCHEDULE is None:
+        run_uv_job(
+            "https://raw.githubusercontent.com/tomaarsen/trending-deploy/refs/heads/scheduled_hf_jobs/cli.py",
+            **kwargs,
+        )
+    else:
+        create_scheduled_uv_job(
+            "https://raw.githubusercontent.com/tomaarsen/trending-deploy/refs/heads/scheduled_hf_jobs/cli.py",
+            schedule=SCHEDULE,
+            **kwargs,
+        )
 
 if __name__ == "__main__":
     main()

--- a/scripts/schedule_hf_job.py
+++ b/scripts/schedule_hf_job.py
@@ -1,0 +1,27 @@
+from huggingface_hub import create_scheduled_uv_job
+import os
+
+BUDGET = 500
+MAX_MODELS_PER_TASK = 30
+HF_TOKEN = os.environ["HF_TOKEN"]
+
+def main():
+    create_scheduled_uv_job(
+        "https://raw.githubusercontent.com/tomaarsen/trending-deploy/refs/heads/scheduled_hf_jobs/cli.py",
+        script_args=[
+            "--budget",
+            str(BUDGET),
+            "--max-models-per-task",
+            str(MAX_MODELS_PER_TASK),
+            "--verbose",
+            "--dry",
+        ],
+        schedule="@weekly",
+        secrets={"HF_TOKEN": HF_TOKEN},
+        flavor="cpu-basic",
+        timeout="2h",
+        namespace="hf-inference",
+    )
+
+if __name__ == "__main__":
+    main()

--- a/scripts/schedule_hf_job.py
+++ b/scripts/schedule_hf_job.py
@@ -19,7 +19,7 @@ def main():
         schedule="@weekly",
         secrets={"HF_TOKEN": HF_TOKEN},
         flavor="cpu-basic",
-        timeout="2h",
+        timeout="8h",
         namespace="hf-inference",
     )
 

--- a/scripts/schedule_hf_job.py
+++ b/scripts/schedule_hf_job.py
@@ -24,12 +24,12 @@ def main():
 
     if SCHEDULE is None:
         run_uv_job(
-            "https://raw.githubusercontent.com/tomaarsen/trending-deploy/refs/heads/scheduled_hf_jobs/cli.py",
+            "https://raw.githubusercontent.com/huggingface/trending-deploy/refs/heads/main/cli.py",
             **kwargs,
         )
     else:
         create_scheduled_uv_job(
-            "https://raw.githubusercontent.com/tomaarsen/trending-deploy/refs/heads/scheduled_hf_jobs/cli.py",
+            "https://raw.githubusercontent.com/huggingface/trending-deploy/refs/heads/main/cli.py",
             schedule=SCHEDULE,
             **kwargs,
         )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+
+from setuptools import find_packages, setup
+
+setup(
+    name="trending_deploy",
+    description="Deploy Trending Models on Hugging Face Inference Endpoints with CPU hardware",
+    version="0.1.0",
+    url="https://github.com/huggingface/trending-deploy",
+    project_urls={
+        "Source Code": "https://github.com/huggingface/trending-deploy",
+        "Issue Tracker": "https://github.com/huggingface/trending-deploy/issues",
+    },
+    license="Apache License, Version 2.0",
+    maintainer="Hugging Face Team",
+    author="Hugging Face Team",
+    python_requires=">=3.8",
+    install_requires=[
+        "numpy",
+        "huggingface_hub",
+    ],
+    packages=find_packages(),
+)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add setup.py so that `trending_deploy` can be installed as a module in Python
* Add simple script to deploy Scheduled Job on HF

## Details
The new `scripts/schedule_hf_job.py` uses the yet-to-be-released `huggingface_hub` version to create a scheduled job via `uv`, pointing to the `cli.py`. The `cli.py` was updated to have `trending_deploy` as a dependency via GitHub. For now I point to my fork & this PR branch, but we'll update to the main repo and branch if it all works.

The test job runs a small dry run weekly on cpu-basic hardware. I'd like to run the `schedule_hf_jobs.py` script when this PR is created so I can test whether it runs correctly. Hopefully there's some okay logging on the jobs on the Hub.

- Tom Aarsen