### PR TITLE
image upgrade: api-inference-8.0.0

### DIFF
--- a/trending_deploy/deploy.py
+++ b/trending_deploy/deploy.py
@@ -21,7 +21,7 @@ ENDPOINT_PREFIX = "auto-"
 COLLECTION_SLUG = "hf-inference/deployed-models-680a42b770e6b6cd546c3fbc"
 DEFAULT_INSTANCE_TYPE = "intel-spr-overcommitted"
 DEFAULT_INSTANCE_SIZE = "x16"
-IMAGE = "registry.internal.huggingface.tech/hf-endpoints/inference-pytorch-cpu:api-inference-7.0.0"
+IMAGE = "registry.internal.huggingface.tech/hf-endpoints/inference-pytorch-cpu:api-inference-8.0.0"
 
 # Instance size mapping based on instance memory
 # Maps instance memory to HF instance size (x1, x2, etc.)


### PR DESCRIPTION
support of deprecated pipelines (summarization, translation, question-answering, table-question-answering) while still using Transformers 5